### PR TITLE
Swap '-' and '_' on line 221 to fix regex syntax

### DIFF
--- a/postgresqltuner.pl
+++ b/postgresqltuner.pl
@@ -218,7 +218,7 @@ if ($host =~ /^\//) {
 	$os_cmd_prefix='';
 } elsif ($host =~ /^127\.[0-9]+\.[0-9]+\.[0-9]+$/) {
 	$os_cmd_prefix='';
-} elsif ($host =~ /^[a-zA-Z0-9.-_]+$/) {
+} elsif ($host =~ /^[a-zA-Z0-9._-]+$/) {
 	$os_cmd_prefix="ssh $ssh_opts $host ";
 } else {
 	die("Invalid host '$host'");


### PR DESCRIPTION
Note that your line 221 has incorrect regex syntax.  The "-" (dash) character needs to come at the end of the sequence, if you're going to allow it as a character within the match, as opposed to a metacharacter indicating a range.