### PR TITLE
freeBSD: freecolor output in bytes

### DIFF
--- a/postgresqltuner.pl
+++ b/postgresqltuner.pl
@@ -297,7 +297,7 @@ print_header_1("OS information");
 			my $os_mem="";
 			if ($os->{name} =~ 'bsd')
 			{
-				$os_mem=os_cmd("freecolor -o");
+				$os_mem=os_cmd("freecolor -ob");
 			}
 			else
 			{


### PR DESCRIPTION
Fix the output of freecolor on freeBSD to match the output of free on linux machines