### PR TITLE
Update README for Fedora Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ apt-get install libdbd-pg-perl libdbi-perl perl-modules
 ```
 - On Fedora or a derivative:
 ```
-yum install perl-DBD-Pg perl-DBI perl-Term-ANSIColor
+dnf install perl-DBD-Pg perl-DBI perl-Term-ANSIColor perl-Memoize
 ```
 
 - On MacOS with Homebrew:


### PR DESCRIPTION
For Fedora and derivatives, `dnf` is now the default package manager.
Perl Memoize is required, so need to be installed as well.