### PR TITLE
#63 Add possibility to skip ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ Allow to specify that storage is on SSD. Especially useful if PostgreSQL runs in
 --nocolor
 The report will not be colorized.  Useful to save it in a file by using shell redirection.
 
+- Skip ssh
+
+When running against an RDS, it is not possible to have a ssh connection to the instance. The option `skip-ssh` option skips the ssh connection and related checks. However, without ssh the script won't be able to search for total_memory. In this case it is possible to manually inform it by using the `memory` parameter. This way we can still have the memory ratio warnings. The memory value should be in **bytes**.
+```
+--skip-ssh --memory=8219082752
+```
+
 ## Special FreeBSD settings
 
 FreeBSD has support for virtual memory over-commit, using vm.overcommit configuration setting.

--- a/README.md
+++ b/README.md
@@ -227,8 +227,12 @@ If the PostgreSQL instance runs in an hypervisor or with SSD storage, I cannot d
 ```
 Allow to specify that storage is on SSD. Especially useful if PostgreSQL runs in a VM using an underlying (on the physical machine) SSD.
 
---nocolor
+- No color
+
 The report will not be colorized.  Useful to save it in a file by using shell redirection.
+```
+--nocolor
+```
 
 - Skip ssh
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ apt-get install libdbd-pg-perl libdbi-perl perl-modules
 ```
 dnf install perl-DBD-Pg perl-DBI perl-Term-ANSIColor perl-Memoize
 ```
+- On Arch or a derivative:
+```
+pacman -S perl-dbi perl-dbd-pg
+```
 
 - On MacOS with Homebrew:
 ```


### PR DESCRIPTION
#63 

When running against an RDS, we wont have ssh connection to the instance. Added option to skip ssh checks, this way `$can_run_os_cmd` will be always false.

Since we won't have ssh, the script won't be able to search for total_memory. Added a new parameter so the total memory of the database can be manually informed. This way we can still have the memory ratio warnings.